### PR TITLE
fix: Prevent db from being created by default

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,12 +41,34 @@ if ! flyctl status --app "$app"; then
   # Backup the original config file since 'flyctl launch' messes up the [build.args] section
   cp "$config" "$config.bak"
 
-  # Deploy with modified config file
-  flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --ha=$INPUT_HA
+  # Deploy with modified config file. Fly.io creates the postgres db even with
+  # the --no-deploy flag, so we need to manually deploy the app
+  # flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --ha=$INPUT_HA
+  # 1. fly apps create
+  # 2. fly ips allocate v4
+  # 3. fly ips allocate v6
+  # 4. fly secrets set
+  # 5. fly deploy
+  # https://community.fly.io/t/launch-an-app-without-a-database/20245
+
+  # 1. Create the app
+  # https://fly.io/docs/flyctl/apps-create/
+  flyctl apps create --name "$app" --org "$org"
+
+  # 2. Allocate an IPv4 address
+  # https://fly.io/docs/flyctl/ips-allocate-v4/
+  flyctl ips allocate-v4 --app "$app" --config "$config" --region "$region"
+
+  # 3. Allocate an IPv6 address
+  # https://fly.io/docs/flyctl/ips-allocate-v6/
+  flyctl ips allocate-v6 --app "$app" --config "$config" --region "$region"
 
   # Restore the original config file
   cp "$config.bak" "$config"
 fi
+
+# 4. Set the secrets
+# https://fly.io/docs/flyctl/secrets-set/
 if [ -n "$INPUT_SECRETS" ]; then
   echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
 fi
@@ -56,7 +78,8 @@ if [ -n "$INPUT_POSTGRES" ]; then
   flyctl postgres attach "$INPUT_POSTGRES" --app "$app" --yes || true
 fi
 
-# Trigger the deploy of the new version.
+# 5. Trigger the deploy of the new version.
+# https://fly.io/docs/flyctl/deploy/
 echo "Contents of config $config file: " && cat "$config"
 if [ -n "$INPUT_VMSIZE" ]; then
   flyctl deploy --config "$config" --app "$app" --regions "$region" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE"
@@ -68,7 +91,7 @@ fi
 flyctl status --app "$app" --json >status.json
 hostname=$(jq -r .Hostname status.json)
 appid=$(jq -r .ID status.json)
-echo "hostname=$hostname" >> $GITHUB_OUTPUT
-echo "url=https://$hostname" >> $GITHUB_OUTPUT
-echo "id=$appid" >> $GITHUB_OUTPUT
-echo "name=$app" >> $GITHUB_OUTPUT
+echo "hostname=$hostname" >>$GITHUB_OUTPUT
+echo "url=https://$hostname" >>$GITHUB_OUTPUT
+echo "id=$appid" >>$GITHUB_OUTPUT
+echo "name=$app" >>$GITHUB_OUTPUT


### PR DESCRIPTION
We use a single db postgres for review apps so KISS, this commit creates an app, allocates ips, attaches the existing db to the $INPUT_POSTGRES variable value and finally deploys the config.

A future update should allow creating the db automatically, or deprecating this functionality in the docs and options.